### PR TITLE
fix: #5/issue pagination in cafe module

### DIFF
--- a/src/cafe/cafe.repository.ts
+++ b/src/cafe/cafe.repository.ts
@@ -108,9 +108,10 @@ export class CafeRepository {
   async getSwipeCafeList(
     userUuid: string,
     query: GetSwipeCafeListDto,
-    page: number,
-    take = 20,
   ): Promise<{ data: GeneralCafeResDto[]; hasNextPage: boolean }> {
+    const page = query.page;
+    const take = query.take;
+
     const skip = (page - 1) * take;
     const limit = take + 1; // +1 to check for the next page
     const DISLIKE_EXPIRE_DAYS = 7;
@@ -145,7 +146,6 @@ export class CafeRepository {
 
     return {
       data: rawResult,
-
       hasNextPage,
     };
   }

--- a/src/cafe/cafe.service.ts
+++ b/src/cafe/cafe.service.ts
@@ -106,33 +106,31 @@ export class CafeService {
   async getSwipeCafeList(
     user: User,
     query: GetSwipeCafeListDto,
-    page = 1,
-    take = 20,
   ): Promise<SwipeCafeListResDto> {
+    // GPS coordinates Validation
     if (!this.isValidKoreanGPS(query.latitude, query.longitude)) {
       throw new BadRequestException(
         'Wrong GPS coordinates (out of South Korea)',
       );
     }
 
-    const { data, hasNextPage } = await this.cafeRepository.getSwipeCafeList(
-      user.uuid,
-      query,
-      page,
-      take,
-    );
-
-    if (page < 1) {
+    // Pagination values Validation
+    if (query.page < 1) {
       throw new BadRequestException('Page must be greater than 0');
     }
 
-    if (take < 1 || take > 20) {
+    if (query.take < 1 || query.take > 20) {
       throw new BadRequestException('Take must be between 1 and 20');
     }
 
+    const { data, hasNextPage } = await this.cafeRepository.getSwipeCafeList(
+      user.uuid,
+      query,
+    );
+
     const result: SwipeCafeListResDto = {
       data,
-      nextPage: page + 1,
+      nextPage: query.page + 1,
       cafeCount: data.length,
       hasNextPage,
     };

--- a/src/cafe/dto/req/getSwipeCafeList.dto.ts
+++ b/src/cafe/dto/req/getSwipeCafeList.dto.ts
@@ -12,7 +12,7 @@ export class GetSwipeCafeListDto extends GetNearCafeListDto {
   @IsNumber()
   @IsOptional()
   @Type(() => Number)
-  page: number;
+  page: number = 1;
 
   @ApiProperty({
     example: 20,


### PR DESCRIPTION
Cafe Module에서 평가 대상 카페 리스트를 불러오는 함수에 Pagination이 정상적으로 적용되지 않는 이슈 해결.

close #5 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified pagination handling for the cafe swipe list by consolidating page and item count inputs into a single query.
  - Default values are now automatically applied (page 1 and 20 items) when no parameters are provided.
  - Optimized the structure of pagination information returned to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->