### PR TITLE
Cafe 정보에 운영시간 정보 추가

### DIFF
--- a/prisma/migrations/20250307003816_add_open_hours/migration.sql
+++ b/prisma/migrations/20250307003816_add_open_hours/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE `OpenHours` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `monday` VARCHAR(191) NULL,
+    `tuesday` VARCHAR(191) NULL,
+    `wednesday` VARCHAR(191) NULL,
+    `thursday` VARCHAR(191) NULL,
+    `friday` VARCHAR(191) NULL,
+    `saturday` VARCHAR(191) NULL,
+    `sunday` VARCHAR(191) NULL,
+    `cafeId` INTEGER NOT NULL,
+
+    UNIQUE INDEX `OpenHours_cafeId_key`(`cafeId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `OpenHours` ADD CONSTRAINT `OpenHours_cafeId_fkey` FOREIGN KEY (`cafeId`) REFERENCES `Cafe`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,6 @@ model Cafe {
   address   String
   latitude  Float // GPS 위도
   longitude Float // GPS 경도
-  // openHours String? // 영업 시간 // 좀 더 세분화 필요
   instagram String? // 가게 인스타 계정 링크
   naverMap  String? // 가게 네이버지도 링크
   phone     String? // 가게 연락처
@@ -36,6 +35,22 @@ model Cafe {
 
   userCafes UserCafe[]
   images    Image[]
+
+  openHours OpenHours?
+}
+
+model OpenHours {
+  id        Int     @id @default(autoincrement())
+  monday    String?
+  tuesday   String?
+  wednesday String?
+  thursday  String?
+  friday    String?
+  saturday  String?
+  sunday    String?
+
+  cafe   Cafe @relation(fields: [cafeId], references: [id])
+  cafeId Int  @unique
 }
 
 enum PreferenceStatus {

--- a/src/cafe/cafe.repository.ts
+++ b/src/cafe/cafe.repository.ts
@@ -27,6 +27,7 @@ export class CafeRepository {
           },
           orderBy: { id: 'asc' },
         },
+        openHours: true,
       },
     });
   }
@@ -67,6 +68,7 @@ export class CafeRepository {
           },
           orderBy: { order: 'asc' },
         },
+        openHours: true,
       },
       orderBy: {
         createdAt: 'desc',
@@ -118,6 +120,7 @@ export class CafeRepository {
           },
           orderBy: { order: 'asc' },
         },
+        openHours: true,
       },
     });
 
@@ -138,7 +141,13 @@ export class CafeRepository {
     return await this.prismaService.cafe.create({
       data: {
         ...createCafeDto,
+        openHours: {
+          create: createCafeDto.openHours,
+        },
         images: {},
+      },
+      include: {
+        openHours: true,
       },
     });
   }
@@ -147,6 +156,9 @@ export class CafeRepository {
     return await this.prismaService.cafe.create({
       data: {
         ...cafeData,
+        openHours: {
+          create: cafeData.openHours,
+        },
         images: {
           create: [
             ...images.map((image, idx) => ({
@@ -169,6 +181,7 @@ export class CafeRepository {
           },
           orderBy: { order: 'asc' },
         },
+        openHours: true,
       },
     });
   }
@@ -195,6 +208,9 @@ export class CafeRepository {
       },
       data: {
         ...updateCafeData,
+        openHours: {
+          update: updateCafeData.openHours,
+        },
       },
       include: {
         images: {
@@ -208,6 +224,7 @@ export class CafeRepository {
           },
           orderBy: { id: 'asc' },
         },
+        openHours: true,
       },
     });
 
@@ -246,9 +263,23 @@ export class CafeRepository {
               'createdAt', i.createdAt
             )
           )
-        END AS images
+        END AS images,
+        CASE
+          WHEN oh.cafeId IS NULL THEN NULL
+          ELSE JSON_OBJECT(
+            'monday', oh.monday,
+            'tuesday', oh.tuesday,
+            'wednesday', oh.wednesday,
+            'thursday', oh.thursday,
+            'friday', oh.friday,
+            'saturday', oh.saturday,
+            'sunday', oh.sunday
+          )
+        END AS openHours
       FROM Cafe AS c
       LEFT JOIN Image AS i ON c.id = i.cafeId
+      LEFT JOIN OpenHours AS oh
+        ON c.id = oh.cafeId
       WHERE ST_Distance_Sphere(
         point(longitude, latitude),
         point(${query.longitude}, ${query.latitude})
@@ -325,13 +356,27 @@ export class CafeRepository {
               'createdAt', i.createdAt
             )
           )
-        END AS images
+        END AS images,
+        CASE
+          WHEN oh.cafeId IS NULL THEN NULL
+          ELSE JSON_OBJECT(
+            'monday', oh.monday,
+            'tuesday', oh.tuesday,
+            'wednesday', oh.wednesday,
+            'thursday', oh.thursday,
+            'friday', oh.friday,
+            'saturday', oh.saturday,
+            'sunday', oh.sunday
+          )
+        END AS openHours
       FROM Cafe AS c
         LEFT JOIN Image AS i 
           ON c.id = i.cafeId
         LEFT JOIN UserCafe AS uc
           ON c.id = uc.cafeId
           AND uc.userUuid = ${userUuid}
+        LEFT JOIN OpenHours AS oh
+          ON c.id = oh.cafeId
       WHERE ST_Distance_Sphere(
         point(c.longitude, c.latitude),
           point(${query.longitude}, ${query.latitude})

--- a/src/cafe/dto/req/createCafe.dto.ts
+++ b/src/cafe/dto/req/createCafe.dto.ts
@@ -5,7 +5,10 @@ import {
   IsOptional,
   IsString,
   IsUrl,
+  ValidateNested,
 } from 'class-validator';
+import { OpenHoursDto } from './openHours.dto';
+import { Type } from 'class-transformer';
 
 export class CreateCafeDto {
   @ApiProperty({
@@ -85,4 +88,14 @@ export class CreateCafeDto {
   @IsString({ each: true })
   @IsOptional()
   images?: string[];
+
+  @ApiProperty({
+    type: OpenHoursDto,
+    description: 'Cafe open hours',
+    required: false,
+  })
+  @ValidateNested()
+  @Type(() => OpenHoursDto)
+  @IsOptional()
+  openHours?: OpenHoursDto;
 }

--- a/src/cafe/dto/req/openHours.dto.ts
+++ b/src/cafe/dto/req/openHours.dto.ts
@@ -1,0 +1,74 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class OpenHoursDto {
+  @ApiProperty({
+    type: String,
+    description: '카페 월요일 운영 시간',
+    example: '09:00-18:00',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  monday?: string;
+
+  @ApiProperty({
+    type: String,
+    description: '카페 화요일 운영 시간',
+    example: '09:00-18:00',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  tuesday?: string;
+
+  @ApiProperty({
+    type: String,
+    description: '카페 수요일 운영 시간',
+    example: '09:00-18:00',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  wednesday?: string;
+
+  @ApiProperty({
+    type: String,
+    description: '카페 목요일 운영 시간',
+    example: '09:00-18:00',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  thursday?: string;
+
+  @ApiProperty({
+    type: String,
+    description: '카페 금요일 운영 시간',
+    example: '09:00-18:00',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  friday?: string;
+
+  @ApiProperty({
+    type: String,
+    description: '카페 토요일 운영 시간',
+    example: '09:00-18:00',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  saturday?: string;
+
+  @ApiProperty({
+    type: String,
+    description: '카페 일요일 운영 시간',
+    example: '09:00-18:00',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  sunday?: string;
+}

--- a/src/cafe/dto/req/pagination.dto.ts
+++ b/src/cafe/dto/req/pagination.dto.ts
@@ -19,8 +19,7 @@ export class PaginationDto {
     description: 'Number of pages to get(default: 20)',
     required: false,
   })
-  @Min(1)
-  @Max(1)
+  @Max(20)
   @IsNumber()
   @IsOptional()
   @Type(() => Number)


### PR DESCRIPTION
추가 및 수정된 기능
1. Prisma에 OpenHours schema 추가 및 Cafe Schema 일부 수정
2. OpenHours dto 추가 및 기존 dto 수정
3. cafe.repository.ts에 create, return value fields에 openhours를 포함하도록 수정

close #14 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added detailed operating hours for cafes, allowing users to view day-by-day schedules.
	- Enhanced cafe management so that creating, updating, and retrieving a cafe now supports incorporating operating hours.
	- Introduced structured input for operating hours to improve API documentation and validation.

- **Chores**
	- Improved pagination limits to provide a broader selection of cafes in listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->