### PR TITLE
fix: preference 관련 docs에서 HOLD 제거

### DIFF
--- a/src/cafe/dto/req/setCafePreference.dto.ts
+++ b/src/cafe/dto/req/setCafePreference.dto.ts
@@ -6,12 +6,12 @@ export class SetCafePreferenceDto {
   @ApiProperty({
     enum: PreferenceStatus,
     enumName: 'Preference Status',
-    description: 'Preference Status Type(LIKE, DISLIKE, HOLD)',
+    description: 'Preference Status Type(LIKE, DISLIKE)',
     example: PreferenceStatus.LIKE,
   })
   @IsNotEmpty()
   @IsEnum(PreferenceStatus, {
-    message: 'status는 LIKE, DISLIKE, HOLD 중 하나여야 합니다.',
+    message: 'status는 LIKE, DISLIKE 중 하나여야 합니다.',
   })
   status: PreferenceStatus;
 }

--- a/src/cafe/dto/res/preferenceStatus.dto.ts
+++ b/src/cafe/dto/res/preferenceStatus.dto.ts
@@ -6,7 +6,7 @@ export class PreferenceStatusDto {
   @ApiProperty({
     enum: PreferenceStatus,
     enumName: 'PreferenceStatus',
-    description: 'Preference Status of Cafe(LIKE, DISLIKE, HOLD)',
+    description: 'Preference Status of Cafe(LIKE, DISLIKE)',
     example: PreferenceStatus.LIKE,
   })
   @IsEnum(PreferenceStatus)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to indicate that only "LIKE" and "DISLIKE" are valid preference statuses, removing references to "HOLD".

- **Bug Fixes**
  - Adjusted validation messages to clarify that only "LIKE" and "DISLIKE" are accepted values for preference status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->