### PR TITLE
Fix/profileimage

### DIFF
--- a/src/auth/types/userInfo.type.ts
+++ b/src/auth/types/userInfo.type.ts
@@ -2,6 +2,6 @@ export type UserInfo = {
   uuid: string;
   kakaoId: string;
   nickname: string;
-  profileImageUrl?: string;
+  profileImageUrl: string | null;
   createdAt: Date;
 };

--- a/src/image/image.service.ts
+++ b/src/image/image.service.ts
@@ -149,6 +149,14 @@ export class ImageService {
   }
 
   /**
+   * 프로필 이미지 삭제
+   * @param key string
+   */
+  async deleteProfileImage(key: string): Promise<void> {
+    await this.deleteFile(key);
+  }
+
+  /**
    * 이미지를 WebP 형식으로 변환
    * @param file Express.Multer.File
    * @returns Express.Multer.File

--- a/src/user/dto/res/userInfo.dto.ts
+++ b/src/user/dto/res/userInfo.dto.ts
@@ -24,12 +24,11 @@ export class UserInfoDto {
 
   @ApiProperty({
     type: String,
-    description: "User's profile image signed URL",
+    description: "User's profile image signed URL or null if no image",
     example:
       'https://your-bucket.s3.region.amazonaws.com/production/profile/1234567890-abcdef.webp?signed-params',
-    required: false,
   })
-  profileImageUrl?: string;
+  profileImageUrl: string | null;
 
   @ApiProperty({
     type: Date,

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -9,6 +9,7 @@ import {
   UseInterceptors,
   UploadedFile,
   BadRequestException,
+  Delete,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { JwtAuthGuard } from 'src/auth/jwt.auth.strategy';
@@ -147,10 +148,27 @@ export class UserController {
       throw new BadRequestException('No file uploaded');
     }
 
-    const updatedUser = await this.userService.updateProfileImage(
-      user.uuid,
-      file,
-    );
+    const updatedUser = await this.userService.updateProfileImage(user, file);
+    return this.userService.formatUserForResponse(updatedUser);
+  }
+
+  @ApiOperation({
+    summary: 'delete profile image',
+    description: '프로필 이미지를 삭제합니다.',
+  })
+  @ApiOkResponse({
+    type: UserInfoDto,
+    description: 'Return updated profile with deleted image',
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal Server Error',
+  })
+  @ApiBearerAuth('JWT')
+  @Delete('profile/image')
+  @UseGuards(JwtAuthGuard)
+  async deleteProfileImage(@GetUser() user: User): Promise<UserInfo> {
+    const updatedUser = await this.userService.deleteProfileImage(user);
     return this.userService.formatUserForResponse(updatedUser);
   }
 }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -57,4 +57,12 @@ export class UserRepository {
       data: { profileImage },
     });
   }
+
+  // 프로필 이미지 삭제
+  async deleteProfileImage(uuid: string) {
+    return this.prismaService.user.update({
+      where: { uuid },
+      data: { profileImage: null },
+    });
+  }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -29,7 +29,10 @@ export class UserService {
     }
 
     const responseUser: UserInfo = {
-      ...user,
+      uuid: user.uuid,
+      kakaoId: user.kakaoId,
+      nickname: user.nickname,
+      createdAt: user.createdAt,
       profileImageUrl: null,
     };
 
@@ -61,10 +64,38 @@ export class UserService {
 
   // 프로필 이미지 업데이트
   async updateProfileImage(
-    uuid: string,
+    user: User,
     file: Express.Multer.File,
   ): Promise<User> {
-    const imageKey = await this.imageService.uploadProfileImage(file);
-    return this.userRepository.updateProfileImage(uuid, imageKey);
+    // 기존 프로필 이미지 키를 저장
+    const oldProfileImageKey = user.profileImage;
+
+    // 새로운 이미지를 먼저 S3에 업로드
+    const newImageKey = await this.imageService.uploadProfileImage(file);
+
+    // DB에 새로운 이미지 키 업데이트
+    const updatedUser = await this.userRepository.updateProfileImage(
+      user.uuid,
+      newImageKey,
+    );
+
+    // 새 이미지 업로드와 DB 업데이트가 성공했을 때만 기존 이미지 삭제
+    if (oldProfileImageKey) {
+      await this.imageService.deleteProfileImage(oldProfileImageKey);
+    }
+
+    return updatedUser;
+  }
+
+  // 프로필 이미지 삭제
+  async deleteProfileImage(user: User): Promise<User> {
+    // S3에서 기존 프로필 이미지 삭제
+    if (user.profileImage) {
+      await this.imageService.deleteProfileImage(user.profileImage);
+      // DB에서 User의 프로필 이미지 삭제 (null로 설정)
+      return this.userRepository.deleteProfileImage(user.uuid);
+    } else {
+      throw new ConflictException('프로필 이미지가 없습니다.');
+    }
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -85,7 +85,11 @@ export class UserService {
 
     // 새 이미지 업로드와 DB 업데이트가 성공했을 때만 기존 이미지 삭제
     if (oldProfileImageKey) {
-      await this.imageService.deleteProfileImage(oldProfileImageKey);
+      try {
+        await this.imageService.deleteProfileImage(oldProfileImageKey);
+      } catch (error) {
+        console.error('기존 프로필 이미지 삭제 실패:', error);
+      }
     }
 
     return updatedUser;

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,4 +1,8 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { UserRepository } from './user.repository';
 import { ImageService } from 'src/image/image.service';
 import { UserInfo } from 'src/auth/types/userInfo.type';
@@ -95,7 +99,7 @@ export class UserService {
       // DB에서 User의 프로필 이미지 삭제 (null로 설정)
       return this.userRepository.deleteProfileImage(user.uuid);
     } else {
-      throw new ConflictException('프로필 이미지가 없습니다.');
+      throw new NotFoundException('프로필 이미지가 없습니다.');
     }
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -28,12 +28,15 @@ export class UserService {
       return null;
     }
 
-    const { profileImage, ...userWithoutProfileImage } = user;
-    const responseUser: UserInfo = userWithoutProfileImage;
+    const responseUser: UserInfo = {
+      ...user,
+      profileImageUrl: null,
+    };
 
-    if (profileImage) {
-      responseUser.profileImageUrl =
-        await this.imageService.generateSignedUrl(profileImage);
+    if (user.profileImage) {
+      responseUser.profileImageUrl = await this.imageService.generateSignedUrl(
+        user.profileImage,
+      );
     }
 
     return responseUser;


### PR DESCRIPTION
1. 프로필 이미지가 없어도 User 데이터 반환 필드에 profileImageUrl에 null로 표기하도록 수정
2. 프로필 이미지 삭제 기능 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint allowing users to delete their profile image.
  
* **Bug Fixes**
  * The profile image URL field is now always present in user information, explicitly set to either a string or null.

* **Documentation**
  * Updated API documentation to clarify the behavior of the profile image URL and document the new delete profile image endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->